### PR TITLE
Fix web scaling by disabling camera2D

### DIFF
--- a/scenes/main_scene.tscn
+++ b/scenes/main_scene.tscn
@@ -24,9 +24,6 @@ text = "Sokoban"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="Camera2D" type="Camera2D" parent="."]
-position = Vector2(576, 324)
-
 [node name="PlayContainer" type="MarginContainer" parent="."]
 offset_left = 448.0
 offset_top = 256.0

--- a/scenes/select/select_scene.tscn
+++ b/scenes/select/select_scene.tscn
@@ -5,9 +5,6 @@
 [node name="SelectScene" type="Node2D"]
 script = ExtResource("1_bej2w")
 
-[node name="Camera2D" type="Camera2D" parent="."]
-position = Vector2(576, 324)
-
 [node name="ScrollContainer" type="ScrollContainer" parent="."]
 offset_right = 592.0
 offset_bottom = 384.0


### PR DESCRIPTION
* Currently disable camera2D to prevent level section disappear when shrinking content.