### PR TITLE
Upgrade to Godot 4.2

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Sokoban"
 run/main_scene="res://scenes/main/main_scene.tscn"
-config/features=PackedStringArray("4.1", "Forward Plus")
+config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://assets/icon.svg"
 
 [autoload]

--- a/scenes/game/game_scene.gd
+++ b/scenes/game/game_scene.gd
@@ -75,7 +75,7 @@ func complete() -> void:
 func _ready():
 	if len(Global.level_data[Global.mod_pack_id][Global.level_pack_id]) <= Global.level_index:
 		# All level solved, return to main scene
-		get_tree().change_scene_to_file("res://scenes/main/main_scene.tscn")
+		get_tree().change_scene_to_file.bind("res://scenes/main/main_scene.tscn").call_deferred()
 	else:
 		generate_level(Global.level_data[Global.mod_pack_id][Global.level_pack_id][Global.level_index])
 


### PR DESCRIPTION
Upgrade the project to Godot 4.2

**Currently 4.2 `change_scene_to_file` behaves differently in 4.1, which is not called deferred.**

**This may cause scene beome a blank screen. Some scenes have to add `call_deferred` to call scene deferred intentionally.**